### PR TITLE
Update ui5-manifest.json

### DIFF
--- a/client/jsonschemas/manifest.schema.json
+++ b/client/jsonschemas/manifest.schema.json
@@ -118,10 +118,28 @@
                     ]
                 },
                 "i18n": {
+                  "bundleUrl": {
                     "type": "string",
                     "maxLength": 100,
                     "default": "i18n.properties",
                     "description": "Relative URL to the properties file that contains the text symbols for the descriptor (The path to the i18n file must not exceed 100 characters)"
+                  },
+                  "fallbackLocale": {
+                    "type": "string",
+                    "maxLength": 5,
+                    "default": "en",
+                    "description": "A BCP47 language tag or a JDK compatible locale string (e.g. “en-GB”, “en_GB” or “en”)"
+                  },
+                  "supportedLocales": {
+                    "type": "array",
+                    "description": "A list of locales for which resource bundles may be requested. If this list is empty or not specified, all locales are supported.",
+                    "items": {
+                      "type": "string",
+                      "maxLength": 5,
+                      "uniqueItems": true,
+                      "description": "A BCP47 language tag or a JDK compatible locale string (e.g. “en-GB”, “en_GB” or “en”)"
+		    }
+		  }
                 },
                 "applicationVersion": {
                     "type": "object",


### PR DESCRIPTION
Update the ui5-manifest.json schema to the version v.1.21.0 according to the change in UI5 1.77.

With manifest version 1.21.0 the sap.app `i18n` section can hold an object containing `bundleUrl`, `supportedLocales`, and `fallbackLocale`.

Details:
* https://sapui5.hana.ondemand.com/#/topic/ec753bc539d748f689e3ac814e129563.html
* https://blogs.sap.com/2020/06/03/ui5ers-buzz-54-i18n-with-supportedlocales-and-fallbacklocale-configuration/